### PR TITLE
fix spacing between IOB and COB when values returned

### DIFF
--- a/M5StickC_NightscoutMon.ino
+++ b/M5StickC_NightscoutMon.ino
@@ -532,7 +532,7 @@ void update_glycemia() {
                     M5.Lcd.setTextColor(TFT_WHITE, TFT_BLACK);
                   else
                     M5.Lcd.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
-                  M5.Lcd.drawString(cob_displayLine, 60, 71, 1);
+                  M5.Lcd.drawString(cob_displayLine, 70, 71, 1);
                 }
               }
             }


### PR DESCRIPTION
When displaying returned IOB and COB, they were displayed as "IOB: 0.28UCOB: 1.2g".  This was difficult to read, so I moved the COB 10 pixels to the right.  This should give a bit more space for IOB to extend with larger quantities without butting against the COB.