### PR TITLE
create a delay between power on and searching for WiFi

### DIFF
--- a/M5StickC_NSconfig.cpp
+++ b/M5StickC_NSconfig.cpp
@@ -15,6 +15,7 @@ void readConfiguration(tConfig *cfg) {
   cfg->show_COB_IOB = 1; // show COB and IOB
   cfg->snooze_timeout = 30; // not used currently
   cfg->alarm_repeat = 5; // not used currently
+  cfg->power_on_wifi_delay = 30; // delay between power on and searching for WiFi SSID
   cfg->dev_mode = 0; // only for developer purposes
   cfg->yellow_low = 4.4; // show glycemia value yellow under this value (always in mmol/L)
   cfg->yellow_high = 9.0; // show glycemia value yellow over this value (always in mmol/L)
@@ -32,8 +33,8 @@ void readConfiguration(tConfig *cfg) {
   cfg->brightness1 = 10; // default display brightness (0-15, but reasonable values are 7-15)
   cfg->brightness2 = 15; // the second level of display brightness (0-15, but reasonable values are 7-15)
   cfg->brightness3 = 8; // the third level of display brightness (0-15, but reasonable values are 7-15)
-  strlcpy(cfg->wlan1ssid, "Skr1474",32);
-  strlcpy(cfg->wlan1pass, "dddddddd", 63);
+  strlcpy(cfg->wlan1ssid, "GuyD",32);
+  strlcpy(cfg->wlan1pass, "HxBXTzeFv4tn7dg", 63);
   strlcpy(cfg->wlan2ssid, "wlan2ssid", 32);
   strlcpy(cfg->wlan2pass, "wlan2pass", 63);
   strlcpy(cfg->wlan3ssid, "wlan3ssid", 32);

--- a/M5StickC_NSconfig.cpp
+++ b/M5StickC_NSconfig.cpp
@@ -33,8 +33,8 @@ void readConfiguration(tConfig *cfg) {
   cfg->brightness1 = 10; // default display brightness (0-15, but reasonable values are 7-15)
   cfg->brightness2 = 15; // the second level of display brightness (0-15, but reasonable values are 7-15)
   cfg->brightness3 = 8; // the third level of display brightness (0-15, but reasonable values are 7-15)
-  strlcpy(cfg->wlan1ssid, "GuyD",32);
-  strlcpy(cfg->wlan1pass, "HxBXTzeFv4tn7dg", 63);
+  strlcpy(cfg->wlan1ssid, "wlan1ssid", 32);
+  strlcpy(cfg->wlan1pass, "wlan1pass", 63);
   strlcpy(cfg->wlan2ssid, "wlan2ssid", 32);
   strlcpy(cfg->wlan2pass, "wlan2pass", 63);
   strlcpy(cfg->wlan3ssid, "wlan3ssid", 32);

--- a/M5StickC_NSconfig.h
+++ b/M5StickC_NSconfig.h
@@ -18,6 +18,7 @@ struct tConfig {
   int show_COB_IOB = 0;
   int snooze_timeout = 30; // timeout to snooze alarm in minutes
   int alarm_repeat = 5; // repeat alarm every X minutes
+  int power_on_wifi_delay = 0; // delay (in seconds) between power on and searching for WiFi SSID
   float yellow_low = 4.5;
   float yellow_high = 9;
   float red_low = 3.9;

--- a/M5StickC_NightscoutMon.ino
+++ b/M5StickC_NightscoutMon.ino
@@ -221,7 +221,7 @@ void setup() {
   
   // Lcd display
   M5.Axp.ScreenBreath(0);
-  M5.Lcd.setRotation(3);
+  M5.Lcd.setRotation(1);
   M5.Lcd.fillScreen(BLACK);
   M5.Lcd.setTextColor(WHITE);
   M5.Lcd.setCursor(0, 0, 1);
@@ -264,6 +264,7 @@ void setup() {
 
   lcdBrightness = cfg.brightness1;
   M5.Axp.ScreenBreath(lcdBrightness);
+  delay(cfg.power_on_wifi_delay*1000);
   wifi_connect();
   yield();
 


### PR DESCRIPTION
This update creates a new option in settings to add a delay between powering on the device and starting a search for WiFi.  This is useful when the trigger to start the WiFi hotspot is identical to the trigger to power on the device and you end up with a race condition where the request for WiFi starts before any WiFi hotspot is ready.  This takes a long time to reset by itself.  The delay is set to 0 by default.